### PR TITLE
Fix feature flagging for abomonation-serialize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-#[cfg(feature = "abomonation")]
+#[cfg(feature = "abomonation-serialize")]
 extern crate abomonation;
 
 extern crate num_traits as num;

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -4,4 +4,5 @@ mod matrix;
 mod matrix_slice;
 mod blas;
 mod serde;
+#[cfg(feature = "abomonation-serialize")]
 mod abomonation;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,6 +5,7 @@ extern crate quickcheck;
 extern crate approx;
 extern crate num_traits as num;
 extern crate serde_json;
+#[cfg(feature = "abomonation-serialize")]
 extern crate abomonation;
 extern crate rand;
 extern crate alga;


### PR DESCRIPTION
The tests can now be run without the abomonation feature. Also fixes a
bug in the feature flagging for abomonation.